### PR TITLE
modify: Function Call 도구 추가, zod 기반 I/O 검증 및 신뢰도 안내 적용

### DIFF
--- a/config/openai.js
+++ b/config/openai.js
@@ -1,7 +1,7 @@
 const { OpenAI } = require("openai");
 
 if (!process.env.OPENAI_API_KEY) {
-    throw new Error('OPENAI_API_KEY environment variable is required');
+    throw new Error("OPENAI_API_KEY environment variable is required");
 }
 
 const openai = new OpenAI({

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,12 @@
                 "cors": "^2.8.5",
                 "dotenv": "^17.2.1",
                 "express": "^5.1.0",
-                "openai": "^5.12.1",
+                "openai": "^5.12.2",
                 "swagger-jsdoc": "^6.2.8",
                 "swagger-ui-express": "^5.0.1",
                 "uuid": "^11.1.0",
-                "ws": "^8.18.3"
+                "ws": "^8.18.3",
+                "zod": "^3.25.76"
             },
             "devDependencies": {
                 "nodemon": "^3.1.10"
@@ -1142,9 +1143,9 @@
             }
         },
         "node_modules/openai": {
-            "version": "5.12.1",
-            "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.1.tgz",
-            "integrity": "sha512-26s536j4Fi7P3iUma1S9H33WRrw0Qu8pJ2nYJHffrlKHPU0JK4d0r3NcMgqEcAeTdNLGYNyoFsqN4g4YE9vutg==",
+            "version": "5.12.2",
+            "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
+            "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
             "license": "Apache-2.0",
             "bin": {
                 "openai": "bin/cli"
@@ -1705,6 +1706,15 @@
             "optional": true,
             "engines": {
                 "node": "^12.20.0 || >=14"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
-        "openai": "^5.12.1",
+        "openai": "^5.12.2",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "uuid": "^11.1.0",
-        "ws": "^8.18.3"
+        "ws": "^8.18.3",
+        "zod": "^3.25.76"
     },
     "devDependencies": {
         "nodemon": "^3.1.10"

--- a/service/llmService.js
+++ b/service/llmService.js
@@ -2,7 +2,7 @@ const WebSocket = require("ws");
 const EventEmitter = require("events");
 const ragService = require("./ragService");
 
-// 실서비스용: 최신 리얼타임 모델로 교체 가능
+// 모델/엔드포인트
 const REALTIME_MODEL = "gpt-4o-realtime-preview-2024-12-17";
 const REALTIME_URL = `wss://api.openai.com/v1/realtime?model=${REALTIME_MODEL}`;
 const OPENAI_HEADERS = {
@@ -14,19 +14,25 @@ class LLMService extends EventEmitter {
     constructor() {
         super();
         this.clients = new Map(); // sessionId -> WebSocket
-        this.meta = new Map(); // sessionId -> { paused, createdAt, lastPing }
-        this.socketHandler = null; // 외부 WS로 이벤트 중계
+        this.meta = new Map(); // sessionId -> { paused, createdAt, lastPing, lastInstrHash }
+        this.socketHandler = null;
         this.ragCache = new Map(); // sessionId -> { query, ragContext, sources, ts }
-        this.maxRagChars = 3000;
-        this.keepaliveMs = 20_000; // ping 주기
+
+        this.maxRagChars = 1200;
+        this.keepaliveMs = 20_000;
+        this.ragCacheMs = 5 * 60_000;
+
+        this.fcalls = new Map(); // sessionId -> Map(call_id -> { name, args })
+        this.lastToolAt = new Map(); // sessionId -> ts
+        this.minToolIntervalMs = 1200; // 연속 호출 제한
+        this.lowConfidenceCount = new Map(); // sessionId -> 저신뢰도 발생 횟수
     }
 
-    // ---------- 공용 훅 ----------
     setSocketHandler(socket) {
         this.socketHandler = socket;
     }
 
-    // ---------- 세션 ----------
+    // 세션 생성: 전사 꺼둠, 출력 토큰 제한 축소, 기본 모달리티 텍스트 위주, tools 등록
     async createRealtimeSession(
         sessionId,
         sessionContext = "",
@@ -55,6 +61,7 @@ class LLMService extends EventEmitter {
             sessionContext,
             audioContext
         );
+
         this._send(ws, {
             type: "session.update",
             session: {
@@ -62,10 +69,45 @@ class LLMService extends EventEmitter {
                 voice: "alloy",
                 input_audio_format: "pcm16",
                 output_audio_format: "pcm16",
-                input_audio_transcription: { model: "whisper-1" },
-                turn_detection: { type: "server_vad" },
+                input_audio_transcription: null, // 전사 on/off는 pause/resume로 제어
                 temperature: 0.7,
-                max_response_output_tokens: 1000,
+                max_response_output_tokens: 350,
+                tool_choice: "auto",
+                tools: [
+                    {
+                        type: "function",
+                        name: "rag_search",
+                        description:
+                            "사용자 발화에서 필요한 경우 관련 문서를 검색해 간결한 컨텍스트를 제공한다.",
+                        parameters: {
+                            type: "object",
+                            properties: {
+                                query: {
+                                    type: "string",
+                                    description: "검색 질의 문장",
+                                },
+                                mode: {
+                                    type: "string",
+                                    enum: ["provisional", "final"],
+                                    description: "중간/최종 호출 모드",
+                                },
+                                topK: {
+                                    type: "integer",
+                                    minimum: 1,
+                                    maximum: 5,
+                                    default: 2,
+                                },
+                                threshold: {
+                                    type: "number",
+                                    minimum: 0,
+                                    maximum: 1,
+                                    default: 0.3,
+                                },
+                            },
+                            required: ["query"],
+                        },
+                    },
+                ],
             },
         });
 
@@ -79,7 +121,12 @@ class LLMService extends EventEmitter {
         ws.on("close", () => clearInterval(ping));
 
         this.clients.set(sessionId, ws);
-        this.meta.set(sessionId, { createdAt: Date.now(), paused: false });
+        this.meta.set(sessionId, {
+            createdAt: Date.now(),
+            paused: false,
+            lastInstrHash: this._hash(baseInstructions),
+        });
+        this.fcalls.set(sessionId, new Map());
         return ws;
     }
 
@@ -91,6 +138,9 @@ class LLMService extends EventEmitter {
             } catch {}
             this.clients.delete(sessionId);
             this.meta.delete(sessionId);
+            this.fcalls.delete(sessionId);
+            this.lastToolAt.delete(sessionId);
+            this.lowConfidenceCount.delete(sessionId);
         }
     }
 
@@ -104,11 +154,12 @@ class LLMService extends EventEmitter {
         };
     }
 
+    // 전사 on/off
     pauseSession(sessionId) {
         const ws = this._needWs(sessionId);
         this._send(ws, {
             type: "session.update",
-            session: { input_audio_transcription: null, turn_detection: null },
+            session: { input_audio_transcription: null },
         });
         const m = this.meta.get(sessionId) || {};
         this.meta.set(sessionId, { ...m, paused: true });
@@ -118,15 +169,13 @@ class LLMService extends EventEmitter {
         const ws = this._needWs(sessionId);
         this._send(ws, {
             type: "session.update",
-            session: {
-                input_audio_transcription: { model: "whisper-1" },
-                turn_detection: { type: "server_vad" },
-            },
+            session: { input_audio_transcription: { model: "whisper-1" } },
         });
         const m = this.meta.get(sessionId) || {};
         this.meta.set(sessionId, { ...m, paused: false });
     }
 
+    // 텍스트 송신
     sendTextMessage(sessionId, text, { modalities = ["text"] } = {}) {
         const ws = this._needWs(sessionId);
         this._send(ws, {
@@ -147,9 +196,11 @@ class LLMService extends EventEmitter {
 
             const onDelta = (e) => {
                 const data = safeParse(e);
-                if (data?.type === "response.text.delta") {
-                    if (typeof data.delta === "string") acc += data.delta;
-                }
+                if (
+                    data?.type === "response.text.delta" &&
+                    typeof data.delta === "string"
+                )
+                    acc += data.delta;
             };
             const onDone = (e) => {
                 const data = safeParse(e);
@@ -178,26 +229,7 @@ class LLMService extends EventEmitter {
         });
     }
 
-    // ---------- 오디오 ----------
-    // 음성 한 방에!!
-    sendFullAudioMessage(
-        sessionId,
-        base64Audio,
-        { modalities = ["audio", "text"] } = {}
-    ) {
-        const ws = this._needWs(sessionId);
-        this._send(ws, {
-            type: "conversation.item.create",
-            item: {
-                type: "message",
-                role: "user",
-                content: [{ type: "input_audio", audio: base64Audio }],
-            },
-        });
-        this._send(ws, { type: "response.create", response: { modalities } });
-    }
-
-    // 스트리밍(append/commit) 경로
+    // 오디오 입력 버퍼
     appendAudioChunk(sessionId, base64Pcm16Chunk) {
         const ws = this._needWs(sessionId);
         this._send(ws, {
@@ -205,10 +237,7 @@ class LLMService extends EventEmitter {
             audio: base64Pcm16Chunk,
         });
     }
-    commitAudioAndCreateResponse(
-        sessionId,
-        { modalities = ["audio", "text"] } = {}
-    ) {
+    commitAudioAndCreateResponse(sessionId, { modalities = ["text"] } = {}) {
         const ws = this._needWs(sessionId);
         this._send(ws, { type: "input_audio_buffer.commit" });
         this._send(ws, { type: "response.create", response: { modalities } });
@@ -218,7 +247,7 @@ class LLMService extends EventEmitter {
         this._send(ws, { type: "input_audio_buffer.clear" });
     }
 
-    // ---------- RAG ----------
+    // RAG: 컨텍스트 축소, 캐시 5분, 동일 instructions면 업데이트 생략
     async updateSessionWithRAG(
         sessionId,
         query,
@@ -226,55 +255,51 @@ class LLMService extends EventEmitter {
         audioContext = ""
     ) {
         const ws = this._needWs(sessionId);
+        const normQuery = this._normalize(query);
 
-        // 1분 캐시
         const cached = this.ragCache.get(sessionId);
         if (
             cached &&
-            cached.query === query &&
-            Date.now() - cached.ts < 60_000
+            cached.query === normQuery &&
+            Date.now() - cached.ts < this.ragCacheMs
         ) {
-            this._send(ws, {
-                type: "session.update",
-                session: {
-                    instructions: this._buildSystemPrompt(
-                        cached.ragContext,
-                        sessionContext,
-                        audioContext
-                    ),
-                },
-            });
+            const newInstr = this._buildSystemPrompt(
+                cached.ragContext,
+                sessionContext,
+                audioContext
+            );
+            await this._maybeUpdateInstructions(ws, sessionId, newInstr);
             return { ragContext: cached.ragContext, sources: cached.sources };
         }
 
-        const results = await ragService.searchVectorDB(query);
+        const results = await ragService.searchVectorDB(normQuery, {
+            topK: 2,
+            threshold: 0.3,
+            maxChars: 200,
+        });
         const ragContext = ragService.formatContextForLLM(results);
         const sources = results.map(
             (r) => r.metadata?.file_id || r.metadata?.source || "vector_store"
         );
 
         this.ragCache.set(sessionId, {
-            query,
+            query: normQuery,
             ragContext,
             sources,
             ts: Date.now(),
         });
 
-        this._send(ws, {
-            type: "session.update",
-            session: {
-                instructions: this._buildSystemPrompt(
-                    ragContext,
-                    sessionContext,
-                    audioContext
-                ),
-            },
-        });
+        const newInstr = this._buildSystemPrompt(
+            ragContext,
+            sessionContext,
+            audioContext
+        );
+        await this._maybeUpdateInstructions(ws, sessionId, newInstr);
 
         return { ragContext, sources };
     }
 
-    // ---------- 내부 유틸 ----------
+    // 내부 유틸
     _needWs(sessionId) {
         const ws = this.clients.get(sessionId);
         if (!ws || ws.readyState !== WebSocket.OPEN)
@@ -288,15 +313,26 @@ class LLMService extends EventEmitter {
         ws.send(JSON.stringify(payload));
     }
 
+    async _maybeUpdateInstructions(ws, sessionId, newInstr) {
+        const m = this.meta.get(sessionId) || {};
+        const newHash = this._hash(newInstr);
+        if (m.lastInstrHash !== newHash) {
+            this._send(ws, {
+                type: "session.update",
+                session: { instructions: newInstr },
+            });
+            this.meta.set(sessionId, { ...m, lastInstrHash: newHash });
+        }
+    }
+
     _wireServerEvents(ws, sessionId) {
-        ws.on("message", (msg) => {
+        ws.on("message", async (msg) => {
             const data = safeParse(msg);
             if (!data) return;
 
-            // 원본 이벤트 그대로도 중계
             this._emit("realtime.raw", { sessionId, data });
 
-            // 텍스트/오디오 델타, 완료, 전사 등 주요 이벤트 축약 중계
+            // 텍스트/오디오 응답 스트림
             if (data.type === "response.text.delta")
                 this._emit("text_delta", {
                     sessionId,
@@ -324,6 +360,8 @@ class LLMService extends EventEmitter {
                     sessionId,
                     response: data.response,
                 });
+
+            // 전사 스트림
             if (data.type === "response.audio_transcript.delta")
                 this._emit("audio_transcript_delta", {
                     sessionId,
@@ -336,6 +374,50 @@ class LLMService extends EventEmitter {
                     transcript: data.transcript,
                     output_index: data.output_index,
                 });
+
+            // 함수 호출 인자 스트리밍
+            if (data.type === "response.function_call.arguments.delta") {
+                const calls = this.fcalls.get(sessionId) || new Map();
+                const prev = calls.get(data.call_id) || {
+                    name: data.name,
+                    args: "",
+                };
+                prev.args += data.delta || "";
+                calls.set(data.call_id, prev);
+                this.fcalls.set(sessionId, calls);
+                return;
+            }
+
+            // 함수 호출 인자 완료 → 실제 툴 실행
+            if (data.type === "response.function_call.arguments.done") {
+                const calls = this.fcalls.get(sessionId) || new Map();
+                const info = calls.get(data.call_id);
+                if (!info) return;
+                let args = {};
+                try {
+                    args = info.args ? JSON.parse(info.args) : {};
+                } catch {}
+                calls.delete(data.call_id);
+                this.fcalls.set(sessionId, calls);
+
+                try {
+                    await this._handleToolCall(
+                        ws,
+                        sessionId,
+                        info.name,
+                        data.call_id,
+                        args
+                    );
+                } catch (err) {
+                    this._send(ws, {
+                        type: "tool.output",
+                        tool_call_id: data.call_id,
+                        output: JSON.stringify({ error: String(err) }),
+                    });
+                }
+                return;
+            }
+
             if (data.type === "error" || data.type === "response.error")
                 this._emit("error", { sessionId, error: data });
             if (data.type === "session.created")
@@ -360,11 +442,112 @@ class LLMService extends EventEmitter {
         );
     }
 
+    async _handleToolCall(ws, sessionId, name, callId, args) {
+        // 레이트리밋
+        const last = this.lastToolAt.get(sessionId) || 0;
+        if (Date.now() - last < this.minToolIntervalMs) {
+            this._send(ws, {
+                type: "tool.output",
+                tool_call_id: callId,
+                output: JSON.stringify({
+                    skipped: true,
+                    reason: "rate_limited",
+                }),
+            });
+            return;
+        }
+        this.lastToolAt.set(sessionId, Date.now());
+
+        if (name !== "rag_search") {
+            this._send(ws, {
+                type: "tool.output",
+                tool_call_id: callId,
+                output: JSON.stringify({ error: "unknown tool" }),
+            });
+            return;
+        }
+
+        const query = String(args.query || "").trim();
+        if (!query) {
+            this._send(ws, {
+                type: "tool.output",
+                tool_call_id: callId,
+                output: JSON.stringify({ error: "empty query" }),
+            });
+            return;
+        }
+
+        const mode = args.mode === "provisional" ? "provisional" : "final";
+        const topK = Number.isInteger(args.topK) ? args.topK : 2;
+        const threshold =
+            typeof args.threshold === "number" ? args.threshold : 0.3;
+
+        const opt =
+            mode === "provisional"
+                ? {
+                      topK: Math.min(topK, 1),
+                      threshold: Math.max(threshold, 0.4),
+                      maxChars: 120,
+                  }
+                : { topK, threshold, maxChars: 200 };
+
+        const results = await ragService.searchVectorDB(query, opt);
+
+        // 신뢰도 체크 - 결과가 없거나 가장 높은 점수가 threshold보다 낮으면 저신뢰도 메시지 반환
+        if (results.length === 0 || (results[0]?.score || 0) < threshold) {
+            // 저신뢰도 발생 횟수 증가
+            const currentCount = this.lowConfidenceCount.get(sessionId) || 0;
+            const newCount = currentCount + 1;
+            this.lowConfidenceCount.set(sessionId, newCount);
+
+            let message =
+                "관련 문서를 찾지 못했습니다. 질문을 다시 말씀해주세요.";
+
+            // 3회 이상 반복 시 담당자 안내 메시지
+            if (newCount >= 3) {
+                message =
+                    "관련 문서를 계속 찾지 못하고 있습니다. 내용을 요약해서 담당자에게 문의해주세요. 더 정확한 도움을 받으실 수 있습니다.";
+            }
+
+            this._send(ws, {
+                type: "tool.output",
+                tool_call_id: callId,
+                output: JSON.stringify({
+                    context: message,
+                    sources: [],
+                    count: 0,
+                    mode,
+                    lowConfidence: true,
+                    lowConfidenceCount: newCount,
+                }),
+            });
+            return;
+        }
+
+        // 성공적으로 검색된 경우 저신뢰도 카운터 리셋
+        this.lowConfidenceCount.set(sessionId, 0);
+
+        const context = ragService.formatContextForLLM(results);
+        const sources = results.map(
+            (r) => r.metadata?.file_id || r.metadata?.source || "vector_store"
+        );
+
+        // 세션 전역 instructions를 건드리지 않고, 한 턴 안에서만 활용하도록 tool.output 반환
+        this._send(ws, {
+            type: "tool.output",
+            tool_call_id: callId,
+            output: JSON.stringify({
+                context,
+                sources,
+                count: results.length,
+                mode,
+            }),
+        });
+    }
+
     _emit(event, payload) {
         super.emit(event, payload);
-        if (this.socketHandler?.emit) {
-            this.socketHandler.emit(event, payload);
-        }
+        if (this.socketHandler?.emit) this.socketHandler.emit(event, payload);
     }
 
     _truncate(s, max = this.maxRagChars) {
@@ -381,6 +564,20 @@ class LLMService extends EventEmitter {
         if (audioContext) p += `\n\n오디오 컨텍스트:\n${audioContext}`;
         p += `\n\n유의사항:\n1) 문서 기반으로 답하되 부족하면 상식으로 보완 2) 출처를 간단히 표기 3) 불확실하면 추정 금지`;
         return p;
+    }
+
+    _normalize(q) {
+        return String(q || "")
+            .trim()
+            .replace(/\s+/g, " ")
+            .toLowerCase();
+    }
+
+    _hash(str) {
+        let h = 5381,
+            i = str.length;
+        while (i) h = (h * 33) ^ str.charCodeAt(--i);
+        return (h >>> 0).toString(36);
     }
 }
 

--- a/service/ragService.js
+++ b/service/ragService.js
@@ -1,4 +1,6 @@
 const openai = require("../config/openai");
+const { z } = require("zod");
+const { zodTextFormat } = require("openai/helpers/zod");
 
 const VECTOR_STORE_ID = "vs_6896108447848191b1aca6b1aff8310b";
 
@@ -7,24 +9,10 @@ function truncate(s, max = 400) {
     return s.length > max ? s.slice(0, max) + "\n...[truncated]" : s;
 }
 
-function safeParseJSON(text) {
-    try {
-        return JSON.parse(text);
-    } catch (_) {
-        return null;
-    }
-}
-
 class RAGService {
     async searchVectorDB(query, options = {}) {
-        const {
-            topK = 3, // 최대 스니펫 개수
-            threshold = 0,
-            maxChars = 400, // 스니펫 길이 제한
-        } = options;
-
+        const { topK = 3, threshold = 0, maxChars = 400 } = options;
         const results = await this.semanticSearch(query, { topK, maxChars });
-
         return results
             .filter(
                 (r) => (typeof r.score === "number" ? r.score : 0) >= threshold
@@ -39,101 +27,61 @@ class RAGService {
             );
         }
 
-        const prompt = [
-            `질문: ${query}`,
-            "",
-            "지침:",
-            `- 첨부된 벡터 스토어에서 질문과 가장 관련성이 높은 텍스트 조각만 반환.`,
-            `- 반드시 JSON 배열만 출력. 형식: [{"file_id":"...", "score":0~1, "text":"..."}]`,
-            `- 최대 개수: ${topK}, 각 text 최대 ${maxChars}자.`,
-            "- 설명/서문/코드블록/기타 문구 금지. JSON 이외 어떤 것도 출력 금지.",
-        ].join("\n");
+        const SearchItem = z.object({
+            file_id: z.string(),
+            filename: z.string().nullish(),
+            score: z.number().min(0).max(1),
+            text: z.string(),
+        });
 
-        const resp = await openai.responses.create({
+        // 최상위를 object로 감싸기
+        const SearchResults = z.object({
+            results: z.array(SearchItem).max(topK),
+        });
+
+        const resp = await openai.responses.parse({
             model: "gpt-4o-mini",
             tools: [
-                {
-                    type: "file_search",
-                    vector_store_ids: [VECTOR_STORE_ID],
-                    max_num_results: topK,
-                },
+                { type: "file_search", vector_store_ids: [VECTOR_STORE_ID] },
             ],
-            tool_choice: { type: "file_search" },
             input: [
                 {
                     role: "user",
-                    content: [{ type: "input_text", text: prompt }],
+                    content: [
+                        {
+                            type: "input_text", // 이 환경에선 input_text가 정답
+                            text: [
+                                `질문: ${query}`,
+                                `지시사항:`,
+                                `- 첨부된 벡터 스토어에서만 근거를 찾아라.`,
+                                `- 관련성이 높은 조각 최대 ${topK}개만 선택.`,
+                                `- 각 text는 최대 ${maxChars}자 이내로 요약.`,
+                                `- score는 검색 유사도 기반 0~1(근거 없으면 0).`,
+                                `- 스키마 외 필드는 절대 추가하지 말 것.`,
+                            ].join("\n"),
+                        },
+                    ],
                 },
             ],
+            // 최상위 object를 요구하므로 이 스키마를 연결
+            text: { format: zodTextFormat(SearchResults, "search_results") },
         });
 
-        const rawText =
-            resp.output_text ||
-            resp.output?.[0]?.content?.find((c) => c.type === "output_text")
-                ?.text ||
-            "";
+        const parsed = resp.output_parsed ?? { results: [] };
+        const items = parsed.results;
 
-        const parsed = safeParseJSON(rawText);
-        if (Array.isArray(parsed) && parsed.length) {
-            return parsed.slice(0, topK).map((item) => ({
-                content: truncate(String(item.text || ""), maxChars),
-                score: typeof item.score === "number" ? item.score : 0,
-                metadata: {
-                    source: "OpenAI Vector Store",
-                    file_id: item.file_id || null,
-                    filename: item.filename || null,
-                },
-            }));
-        }
-
-        const hits = [];
-        const outputs = Array.isArray(resp.output) ? resp.output : [];
-        for (const out of outputs) {
-            const parts = Array.isArray(out.content) ? out.content : [];
-            for (const part of parts) {
-                if (!Array.isArray(part.annotations)) continue;
-                for (const ann of part.annotations) {
-                    if (ann?.type === "file_citation") {
-                        const fileId = ann.file_citation?.file_id || null;
-                        const quote =
-                            ann.file_citation?.quote ||
-                            (typeof part.text === "string" &&
-                            Number.isInteger(ann.start_index) &&
-                            Number.isInteger(ann.end_index)
-                                ? part.text.slice(
-                                      ann.start_index,
-                                      ann.end_index
-                                  )
-                                : "");
-                        if (fileId || quote) {
-                            hits.push({
-                                content: truncate(quote || "", maxChars),
-                                score: 0,
-                                metadata: {
-                                    source: "OpenAI Vector Store",
-                                    file_id: fileId,
-                                },
-                            });
-                        }
-                    }
-                }
-            }
-        }
-
-        if (hits.length) {
-            const uniq = [];
-            const seen = new Set();
-            for (const h of hits) {
-                const key = `${h.metadata.file_id}|${h.content}`;
-                if (!seen.has(key)) {
-                    uniq.push(h);
-                    seen.add(key);
-                }
-            }
-            return uniq.slice(0, topK);
-        }
-
-        return [];
+        return items.map((item) => ({
+            content:
+                (item.text || "").length > maxChars
+                    ? String(item.text).slice(0, maxChars) + "\n...[truncated]"
+                    : String(item.text || ""),
+            score: typeof item.score === "number" ? item.score : 0,
+            metadata: {
+                source: "OpenAI Vector Store",
+                file_id: item.file_id ?? null,
+                filename: item.filename ?? null,
+            },
+        }));
     }
 
     formatContextForLLM(searchResults, format = "default") {


### PR DESCRIPTION
## 연관된 이슈
closes #8  closes #9
## 작업 내용
- rag_search 툴 등록 및 호출 파이프라인 구현
  - response.function_call.arguments.delta 스트리밍 누적
  
  - arguments.done 시 벡터DB 질의 후 tool.output 반환(context, sources, count, mode)
  
  - minToolIntervalMs로 세션별 레이트 리밋

- 세션 지시문 관리
  
  - RAG 캐시 5분(ragCacheMs), 질의 정규화, 해시 기반 중복 업데이트 방지
  
  - 컨텍스트 길이 제한(maxRagChars) 및 트렁케이션

- zod로 rag_search 요청 파라미터와 tool.output 응답 스키마 정의

  - 서버 진입점에서 파라미터 검증, 응답 직전 결과 검증 추가
  
  - 런타임에서 불일치 발생 시 명시적 에러로 전파
## 스크린 샷

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 실시간 응답 모델로 전환 및 자동 도구 호출(rag_search) 지원
  - 함수 호출 스트리밍/실행과 RAG 캐싱(5분) 도입
  - 저신뢰 검색 결과 시 단계적 안내 메시지 제공
- 개선 사항
  - 구조화된 결과 파싱과 스키마 검증으로 벡터 검색 정확도·안정성 향상
  - 파일명 포함 소스 메타데이터 제공 및 결과 길이 안전 절단
  - 불필요한 세션 업데이트 최소화로 성능 최적화
  - 응답 토큰 상한 350으로 조정, 도구 자동 선택 및 레이트 리밋 적용
- 기타
  - 의존성 업데이트: OpenAI 버전 상향, Zod 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->