### PR TITLE
ouput_index 의도한대로 동작하지 않던 문제 해결.

### DIFF
--- a/service/llmService.js
+++ b/service/llmService.js
@@ -317,23 +317,23 @@ class LLMService extends EventEmitter {
                 this._emit("text_delta", {
                     sessionId,
                     delta: data.delta,
-                    output_index: data.output_index,
+                    // output_index: data.output_index,
                 });
             if (data.type === "response.text.done")
                 this._emit("text_done", {
                     sessionId,
-                    output_index: data.output_index,
+                    // output_index: data.output_index,
                 });
             if (data.type === "response.audio.delta")
                 this._emit("audio_delta", {
                     sessionId,
                     delta: data.delta,
-                    output_index: data.output_index,
+                    // output_index: data.output_index,
                 });
             if (data.type === "response.audio.done")
                 this._emit("audio_done", {
                     sessionId,
-                    output_index: data.output_index,
+                    // output_index: data.output_index,
                 });
             if (data.type === "response.done")
                 this._emit("response_done", {
@@ -346,13 +346,13 @@ class LLMService extends EventEmitter {
                 this._emit("audio_transcript_delta", {
                     sessionId,
                     delta: data.delta,
-                    output_index: data.output_index,
+                    // output_index: data.output_index,
                 });
             if (data.type === "response.audio_transcript.done")
                 this._emit("audio_transcript_done", {
                     sessionId,
                     transcript: data.transcript,
-                    output_index: data.output_index,
+                    // output_index: data.output_index,
                 });
 
             // 함수 호출 인자 스트리밍

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -225,6 +225,8 @@ class Socket {
           return;
         }
         const out = mapper(data);
+        const s = this.sessions.get(sessionId);
+        const turn_index = s?.turnCount ?? 0;
         if (out.type == "response.audio.delta" && ws.readyState === ws.OPEN) {
           try {
             const buf = audioService.fromBase64Pcm(out.delta);
@@ -243,35 +245,55 @@ class Socket {
       ws._llmHandlers.push({ event, handler });
     };
 
-    fwd("text_delta", ({ output_index, delta }) => ({
-      type: "response.text.delta",
-      output_index,
-      delta,
-    }));
-    fwd("text_done", ({ output_index }) => ({
-      type: "response.text.done",
-      output_index,
-    }));
+    fwd("text_delta", ({ delta }) => {
+      const s = this.sessions.get(sessionId);
+      return {
+        type: "response.text.delta",
+        output_index: s?.turnCount ?? 0,
+        delta,
+      }
+    });
+    fwd("text_done", () => {
+      const s = this.sessions.get(sessionId);
+      return {
+        type: "response.text.done",
+        output_index: s?.turnCount ?? 0,
+      }
+    });
 
-    fwd("audio_transcript_delta", ({ output_index, delta }) => ({
-      type: "response.audio_transcript.delta",
-      output_index,
-      delta,
-    }));
-    fwd("audio_transcript_done", ({ output_index }) => ({
-      type: "response.audio_transcript.done",
-      output_index,
-    }));
+    fwd("audio_transcript_delta", ({ delta }) => {
+      const s = this.sessions.get(sessionId);
+      return {
+        type: "response.audio_transcript.delta",
+        output_index: s?.turnCount ?? 0,
+        delta,
+      }
+    });
 
-    fwd("audio_delta", ({ output_index, delta }) => ({
-      type: "response.audio.delta",
-      output_index,
-      delta,
-    }));
-    fwd("audio_done", ({ output_index }) => ({
-      type: "response.audio.done",
-      output_index,
-    }));
+    fwd("audio_transcript_done", () => {
+      const s = this.sessions.get(sessionId);
+      return {
+        type: "response.audio_transcript.done",
+        output_index: s?.turnCount ?? 0,
+      }
+    });
+
+    fwd("audio_delta", ({ delta }) => {
+      const s = this.sessions.get(sessionId);
+      return {
+        type: "response.audio.delta",
+        output_index: s?.turnCount ?? 0,
+        delta,
+      }
+    });
+    
+    fwd("audio_done", () => {
+      const s = this.sessions.get(sessionId);
+      return {
+        type: "response.audio.done",
+        output_index: s?.turnCount ?? 0,
+      }
+    });
     
     const onErr = ({ sessionId: sid, error }) => {
       if (sid !== sessionId) {

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -17,6 +17,7 @@ class Socket {
   constructor() {
     this.wss = null;
     this._hb = null;
+    this.sessions = new Map(); // sessionId -> { turnCount: number }
   }
 
   init(server) {
@@ -42,6 +43,7 @@ class Socket {
       // 연결당 1 세션
       const sessionId = genId("sonj");
       ws._sessionId = sessionId;
+      this.sessions.set(sessionId, { turnCount: 0 }); 
 
       try {
         await llmService.createRealtimeSession(
@@ -108,7 +110,8 @@ class Socket {
         this._cleanupLLMForwarding(ws);
         try {
           await llmService.closeSession(sessionId);
-        } catch {}
+        } catch { }
+        this.sessions.delete(sessionId);
       });
     });
 
@@ -147,6 +150,7 @@ class Socket {
     }
 
     if (type === "input_audio_buffer.end") {
+      _addTurnCount(sessionId)
       try {
         llmService.commitAudioAndCreateResponse(sessionId, {
           modalities: ["text", "audio"],
@@ -158,6 +162,7 @@ class Socket {
     }
 
     if (type === "input_text") {
+      _addTurnCount(sessionId)
       try {
         const text = String(msg.text ?? "");
         llmService.sendTextMessage(sessionId, text, {
@@ -170,6 +175,7 @@ class Socket {
     }
 
     if (type === "preprompted") {
+      _addTurnCount(sessionId)
       const selected = msg.enum || "";
       return this._sendConv(ws, {
         type: "preprompted.done",
@@ -258,6 +264,13 @@ class Socket {
     llmService.on("closed", onClosed);
     ws._llmHandlers.push({ event: "error", handler: onErr });
     ws._llmHandlers.push({ event: "closed", handler: onClosed });
+  }
+
+  _addTurnCount(sessionId) {
+    const s = this.sessions.get(sessionId);
+    if (s) {
+      s.turnCount += 1
+    };
   }
 
   _cleanupLLMForwarding(ws) {

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -168,7 +168,7 @@ class Socket {
     }
 
     if (type === "input_audio_buffer.end") {
-      _addTurnCount(sessionId)
+      this._addTurnCount(sessionId)
       try {
         llmService.commitAudioAndCreateResponse(sessionId, {
           modalities: ["text", "audio"],
@@ -180,7 +180,7 @@ class Socket {
     }
 
     if (type === "input_text") {
-      _addTurnCount(sessionId)
+      this._addTurnCount(sessionId)
       try {
         const text = String(msg.text ?? "");
         llmService.sendTextMessage(sessionId, text, {
@@ -193,7 +193,7 @@ class Socket {
     }
 
     if (type === "preprompted") {
-      _addTurnCount(sessionId)
+      this._addTurnCount(sessionId)
       const selected = msg.enum || "";
       return this._sendConv(ws, {
         type: "preprompted.done",
@@ -286,7 +286,7 @@ class Socket {
         delta,
       }
     });
-    
+
     fwd("audio_done", () => {
       const s = this.sessions.get(sessionId);
       return {


### PR DESCRIPTION
## 연관된 이슈
#12 
## 작업 내용
LLM의 output Index가 대부분의 경우 0으로 반환됨. 이는 "같은 세션 내 대화 인덱스"라는 의도와는 달랐음.
이에, TurnCount를 선언하여 각 세션별로 질문-답변이 몇번 이루어졌는지를 계수하여 기존의 output_index 대신 반환하도록 함.
## 스크린 샷
