### PR TITLE
요약 요청 시 client에 요약 텍스트 가는 문제, 배포 환경 요약 실패 문제

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,21 @@
 # 베이스 이미지
 FROM node:18-alpine
 
+# Puppeteer 의존성 설치
+RUN apk add --no-cache \
+    chromium \
+    nss \
+    freetype \
+    freetype-dev \
+    harfbuzz \
+    ca-certificates \
+    ttf-freefont \
+    && rm -rf /var/cache/apk/*
+
+# Puppeteer가 설치된 Chromium을 사용하도록 설정
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser
+
 # 작업 디렉토리 설정
 WORKDIR /app
 

--- a/service/llmService.js
+++ b/service/llmService.js
@@ -202,8 +202,9 @@ class LLMService extends EventEmitter {
         this._send(ws, { type: "response.create", response: { modalities } });
     }
 
-    sendTextMessageWithResponse(sessionId, text) {
+    sendTextMessageWithResponse(sessionId, text, options = {}) {
         const ws = this._needWs(sessionId);
+        const { silent = false } = options;
         return new Promise((resolve, reject) => {
             let acc = "";
 
@@ -217,10 +218,21 @@ class LLMService extends EventEmitter {
             };
             const onDone = (e) => {
                 const data = safeParse(e);
-                if (data?.type === "response.done") {
+                if (
+                    data?.type === "response.text.done" ||
+                    data?.type === "response.done"
+                ) {
                     ws.off?.("message", onDelta);
                     ws.off?.("message", onDone);
                     ws.off?.("message", onErrorEvt);
+
+                    // silent 모드 해제
+                    if (silent) {
+                        const meta = this.meta.get(sessionId) || {};
+                        delete meta.silent;
+                        this.meta.set(sessionId, meta);
+                    }
+
                     resolve({ text: acc, raw: data });
                 }
             };
@@ -230,6 +242,14 @@ class LLMService extends EventEmitter {
                     ws.off?.("message", onDelta);
                     ws.off?.("message", onDone);
                     ws.off?.("message", onErrorEvt);
+
+                    // silent 모드 해제
+                    if (silent) {
+                        const meta = this.meta.get(sessionId) || {};
+                        delete meta.silent;
+                        this.meta.set(sessionId, meta);
+                    }
+
                     reject(new Error(data?.message || "realtime error"));
                 }
             };
@@ -237,6 +257,12 @@ class LLMService extends EventEmitter {
             ws.on("message", onDelta);
             ws.on("message", onDone);
             ws.on("message", onErrorEvt);
+
+            // silent 모드 설정
+            if (silent) {
+                const meta = this.meta.get(sessionId) || {};
+                this.meta.set(sessionId, { ...meta, silent: true });
+            }
 
             this.sendTextMessage(sessionId, text, { modalities: ["text"] });
         });
@@ -304,18 +330,26 @@ class LLMService extends EventEmitter {
 
                 // 텍스트/오디오 응답 스트림
                 case "response.text.delta":
-                    this._emit("text_delta", {
-                        sessionId,
-                        delta: data.delta,
-                        // output_index: data.output_index,
-                    });
+                    // silent 모드 체크
+                    const meta = this.meta.get(sessionId);
+                    if (!meta?.silent) {
+                        this._emit("text_delta", {
+                            sessionId,
+                            delta: data.delta,
+                            // output_index: data.output_index,
+                        });
+                    }
                     break;
 
                 case "response.text.done":
-                    this._emit("text_done", {
-                        sessionId,
-                        // output_index: data.output_index,
-                    });
+                    // silent 모드 체크
+                    const metaDone = this.meta.get(sessionId);
+                    if (!metaDone?.silent) {
+                        this._emit("text_done", {
+                            sessionId,
+                            // output_index: data.output_index,
+                        });
+                    }
                     break;
 
                 case "response.audio.delta":
@@ -701,7 +735,6 @@ class LLMService extends EventEmitter {
             };
 
             this._emit("office_info", officeInfo);
-        } else {
         }
     }
 

--- a/service/llmService.js
+++ b/service/llmService.js
@@ -353,18 +353,26 @@ class LLMService extends EventEmitter {
                     break;
 
                 case "response.audio.delta":
-                    this._emit("audio_delta", {
-                        sessionId,
-                        delta: data.delta,
-                        // output_index: data.output_index,
-                    });
+                    // silent 모드 체크
+                    const metaAudioDelta = this.meta.get(sessionId);
+                    if (!metaAudioDelta?.silent) {
+                        this._emit("audio_delta", {
+                            sessionId,
+                            delta: data.delta,
+                            // output_index: data.output_index,
+                        });
+                    }
                     break;
 
                 case "response.audio.done":
-                    this._emit("audio_done", {
-                        sessionId,
-                        // output_index: data.output_index,
-                    });
+                    // silent 모드 체크
+                    const metaAudioDone = this.meta.get(sessionId);
+                    if (!metaAudioDone?.silent) {
+                        this._emit("audio_done", {
+                            sessionId,
+                            // output_index: data.output_index,
+                        });
+                    }
                     break;
 
                 case "response.done":
@@ -375,19 +383,27 @@ class LLMService extends EventEmitter {
                     break;
 
                 case "response.audio_transcript.delta":
-                    this._emit("audio_transcript_delta", {
-                        sessionId,
-                        delta: data.delta,
-                        // output_index: data.output_index,
-                    });
+                    // silent 모드 체크
+                    const metaAudioTransDelta = this.meta.get(sessionId);
+                    if (!metaAudioTransDelta?.silent) {
+                        this._emit("audio_transcript_delta", {
+                            sessionId,
+                            delta: data.delta,
+                            // output_index: data.output_index,
+                        });
+                    }
                     break;
 
                 case "response.audio_transcript.done":
-                    this._emit("audio_transcript_done", {
-                        sessionId,
-                        transcript: data.transcript,
-                        // output_index: data.output_index,
-                    });
+                    // silent 모드 체크
+                    const metaAudioTransDone = this.meta.get(sessionId);
+                    if (!metaAudioTransDone?.silent) {
+                        this._emit("audio_transcript_done", {
+                            sessionId,
+                            transcript: data.transcript,
+                            // output_index: data.output_index,
+                        });
+                    }
                     break;
 
                 // 전사 스트림

--- a/service/llmService.js
+++ b/service/llmService.js
@@ -15,6 +15,7 @@ class LLMService extends EventEmitter {
         super();
         this.clients = new Map(); // sessionId -> WebSocket
         this.meta = new Map(); // sessionId -> { paused, createdAt, lastPing, lastInstrHash }
+        this.conversations = new Map(); // sessionId -> [{ role, content, timestamp }]
         this.socketHandler = null;
         this.ragCache = new Map(); // sessionId -> { query, ragContext, sources, ts }
 
@@ -189,8 +190,19 @@ class LLMService extends EventEmitter {
     }
 
     // 텍스트 송신
-    sendTextMessage(sessionId, text, { modalities = ["text"] } = {}) {
+    sendTextMessage(sessionId, text, { modalities = ["text", "audio"] } = {}) {
         const ws = this._needWs(sessionId);
+
+        // 대화 내역에 사용자 메시지 추가
+        if (!this.conversations.has(sessionId)) {
+            this.conversations.set(sessionId, []);
+        }
+        this.conversations.get(sessionId).push({
+            role: "user",
+            content: text,
+            timestamp: Date.now(),
+        });
+
         this._send(ws, {
             type: "conversation.item.create",
             item: {
@@ -202,70 +214,62 @@ class LLMService extends EventEmitter {
         this._send(ws, { type: "response.create", response: { modalities } });
     }
 
-    sendTextMessageWithResponse(sessionId, text, options = {}) {
-        const ws = this._needWs(sessionId);
-        const { silent = false } = options;
-        return new Promise((resolve, reject) => {
-            let acc = "";
+    getSessionConversation(sessionId) {
+        // 추적된 대화 내역 반환
+        const conversation = this.conversations.get(sessionId) || [];
+        return conversation;
+    }
 
-            const onDelta = (e) => {
-                const data = safeParse(e);
-                if (
-                    data?.type === "response.text.delta" &&
-                    typeof data.delta === "string"
-                )
-                    acc += data.delta;
-            };
-            const onDone = (e) => {
-                const data = safeParse(e);
-                if (
-                    data?.type === "response.text.done" ||
-                    data?.type === "response.done"
-                ) {
-                    ws.off?.("message", onDelta);
-                    ws.off?.("message", onDone);
-                    ws.off?.("message", onErrorEvt);
+    // OpenAI Chat Completions API로 요약 생성
+    async generateSummaryWithChatAPI(sessionId, summaryPrompt) {
+        const conversation = this.getSessionConversation(sessionId);
 
-                    // silent 모드 해제
-                    if (silent) {
-                        const meta = this.meta.get(sessionId) || {};
-                        delete meta.silent;
-                        this.meta.set(sessionId, meta);
-                    }
+        if (conversation.length === 0) {
+            throw new Error("대화 내역이 없습니다.");
+        }
 
-                    resolve({ text: acc, raw: data });
+        // 대화 내역을 텍스트로 변환
+        const conversationText = conversation
+            .map(
+                (msg) =>
+                    `${msg.role === "user" ? "고객" : "상담원"}: ${msg.content}`
+            )
+            .join("\n\n");
+
+        const messages = [
+            {
+                role: "user",
+                content: `다음 고객 상담 대화를 요약해주세요:\n\n${conversationText}\n\n${summaryPrompt}`,
+            },
+        ];
+
+        try {
+            const response = await fetch(
+                "https://api.openai.com/v1/chat/completions",
+                {
+                    method: "POST",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+                    },
+                    body: JSON.stringify({
+                        model: "gpt-3.5-turbo",
+                        messages: messages,
+                        temperature: 0.7,
+                        max_tokens: 1500,
+                    }),
                 }
-            };
-            const onErrorEvt = (e) => {
-                const data = safeParse(e);
-                if (data?.type === "error" || data?.type === "response.error") {
-                    ws.off?.("message", onDelta);
-                    ws.off?.("message", onDone);
-                    ws.off?.("message", onErrorEvt);
+            );
 
-                    // silent 모드 해제
-                    if (silent) {
-                        const meta = this.meta.get(sessionId) || {};
-                        delete meta.silent;
-                        this.meta.set(sessionId, meta);
-                    }
-
-                    reject(new Error(data?.message || "realtime error"));
-                }
-            };
-
-            ws.on("message", onDelta);
-            ws.on("message", onDone);
-            ws.on("message", onErrorEvt);
-
-            // silent 모드 설정
-            if (silent) {
-                const meta = this.meta.get(sessionId) || {};
-                this.meta.set(sessionId, { ...meta, silent: true });
+            if (!response.ok) {
+                throw new Error(`OpenAI API 오류: ${response.status}`);
             }
 
-            this.sendTextMessage(sessionId, text, { modalities: ["text"] });
-        });
+            const data = await response.json();
+            return data.choices[0].message.content;
+        } catch (error) {
+            throw new Error(`요약 생성 실패: ${error.message}`);
+        }
     }
 
     // 오디오 입력 버퍼
@@ -276,7 +280,10 @@ class LLMService extends EventEmitter {
             audio: base64Pcm16Chunk,
         });
     }
-    commitAudioAndCreateResponse(sessionId, { modalities = ["text"] } = {}) {
+    commitAudioAndCreateResponse(
+        sessionId,
+        { modalities = ["text", "audio"] } = {}
+    ) {
         const ws = this._needWs(sessionId);
         this._send(ws, { type: "input_audio_buffer.commit" });
         this._send(ws, { type: "response.create", response: { modalities } });
@@ -330,49 +337,56 @@ class LLMService extends EventEmitter {
 
                 // 텍스트/오디오 응답 스트림
                 case "response.text.delta":
-                    // silent 모드 체크
-                    const meta = this.meta.get(sessionId);
-                    if (!meta?.silent) {
-                        this._emit("text_delta", {
-                            sessionId,
-                            delta: data.delta,
-                            // output_index: data.output_index,
-                        });
-                    }
+                    // 세션별 텍스트 누적
+                    const meta = this.meta.get(sessionId) || {};
+                    meta.accumulatedText =
+                        (meta.accumulatedText || "") + data.delta;
+                    this.meta.set(sessionId, meta);
+                    // 일반 대화 응답
+                    this._emit("text_delta", {
+                        sessionId,
+                        delta: data.delta,
+                        // output_index: data.output_index,
+                    });
                     break;
 
                 case "response.text.done":
-                    // silent 모드 체크
-                    const metaDone = this.meta.get(sessionId);
-                    if (!metaDone?.silent) {
-                        this._emit("text_done", {
-                            sessionId,
-                            // output_index: data.output_index,
+                    // 누적된 텍스트를 대화 내역에 추가
+                    const metaDone = this.meta.get(sessionId) || {};
+                    if (metaDone.accumulatedText) {
+                        if (!this.conversations.has(sessionId)) {
+                            this.conversations.set(sessionId, []);
+                        }
+                        this.conversations.get(sessionId).push({
+                            role: "assistant",
+                            content: metaDone.accumulatedText,
+                            timestamp: Date.now(),
                         });
                     }
+
+                    // 누적된 텍스트 초기화
+                    delete metaDone.accumulatedText;
+                    this.meta.set(sessionId, metaDone);
+
+                    this._emit("text_done", {
+                        sessionId,
+                        // output_index: data.output_index,
+                    });
                     break;
 
                 case "response.audio.delta":
-                    // silent 모드 체크
-                    const metaAudioDelta = this.meta.get(sessionId);
-                    if (!metaAudioDelta?.silent) {
-                        this._emit("audio_delta", {
-                            sessionId,
-                            delta: data.delta,
-                            // output_index: data.output_index,
-                        });
-                    }
+                    this._emit("audio_delta", {
+                        sessionId,
+                        delta: data.delta,
+                        // output_index: data.output_index,
+                    });
                     break;
 
                 case "response.audio.done":
-                    // silent 모드 체크
-                    const metaAudioDone = this.meta.get(sessionId);
-                    if (!metaAudioDone?.silent) {
-                        this._emit("audio_done", {
-                            sessionId,
-                            // output_index: data.output_index,
-                        });
-                    }
+                    this._emit("audio_done", {
+                        sessionId,
+                        // output_index: data.output_index,
+                    });
                     break;
 
                 case "response.done":
@@ -383,27 +397,19 @@ class LLMService extends EventEmitter {
                     break;
 
                 case "response.audio_transcript.delta":
-                    // silent 모드 체크
-                    const metaAudioTransDelta = this.meta.get(sessionId);
-                    if (!metaAudioTransDelta?.silent) {
-                        this._emit("audio_transcript_delta", {
-                            sessionId,
-                            delta: data.delta,
-                            // output_index: data.output_index,
-                        });
-                    }
+                    this._emit("audio_transcript_delta", {
+                        sessionId,
+                        delta: data.delta,
+                        // output_index: data.output_index,
+                    });
                     break;
 
                 case "response.audio_transcript.done":
-                    // silent 모드 체크
-                    const metaAudioTransDone = this.meta.get(sessionId);
-                    if (!metaAudioTransDone?.silent) {
-                        this._emit("audio_transcript_done", {
-                            sessionId,
-                            transcript: data.transcript,
-                            // output_index: data.output_index,
-                        });
-                    }
+                    this._emit("audio_transcript_done", {
+                        sessionId,
+                        transcript: data.transcript,
+                        // output_index: data.output_index,
+                    });
                     break;
 
                 // 전사 스트림
@@ -670,7 +676,7 @@ class LLMService extends EventEmitter {
         });
         this._send(ws, {
             type: "response.create",
-            response: { modalities: ["text"] },
+            response: { modalities: ["text", "audio"] },
         });
     }
 

--- a/service/llmService.js
+++ b/service/llmService.js
@@ -253,7 +253,7 @@ class LLMService extends EventEmitter {
                         Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
                     },
                     body: JSON.stringify({
-                        model: "gpt-3.5-turbo",
+                        model: "gpt-4o-mini",
                         messages: messages,
                         temperature: 0.7,
                         max_tokens: 1500,

--- a/service/ragService.js
+++ b/service/ragService.js
@@ -19,13 +19,22 @@ class RAGService {
 
     async semanticSearch(
         query,
-        { topK = 3, maxChars = 400, vectorStoreId = VECTOR_STORE_IDS.DISTRICT_OFFICE } = {}
+        {
+            topK = 3,
+            maxChars = 400,
+            vectorStoreId = VECTOR_STORE_IDS.DISTRICT_OFFICE,
+        } = {}
     ) {
         const targetVectorStoreId = vectorStoreId;
 
-        if (typeof targetVectorStoreId !== "string" || targetVectorStoreId.length === 0) {
+        if (
+            typeof targetVectorStoreId !== "string" ||
+            targetVectorStoreId.length === 0
+        ) {
             throw new Error(
-                `vectorStoreId must be a non-empty string. got: ${String(targetVectorStoreId)}`
+                `vectorStoreId must be a non-empty string. got: ${String(
+                    targetVectorStoreId
+                )}`
             );
         }
 

--- a/service/summaryService.js
+++ b/service/summaryService.js
@@ -33,8 +33,8 @@ class SummaryService {
         }
     }
 
-    // Realtime API에서 직접 구조화된 요약 요청 (silent 모드 사용)
-    async _getStructuredSummaryFromRealtime(llmService, sessionId) {
+    // Chat Completions API로 구조화된 요약 생성
+    async _getStructuredSummaryFromChat(llmService, sessionId) {
         try {
             const summaryPrompt = `지금까지의 고객 상담 내용을 담당자 인수인계용으로 정확하고 자세하게 구조화해서 요약해주세요.
 
@@ -66,21 +66,20 @@ class SummaryService {
 
 **중요: 각 항목의 제목을 정확히 유지하고, 내용은 구체적이고 실용적으로 작성하세요.**`;
 
-            const response = await llmService.sendTextMessageWithResponse(
+            const summaryText = await llmService.generateSummaryWithChatAPI(
                 sessionId,
-                summaryPrompt,
-                { silent: true }
+                summaryPrompt
             );
-            return response.text;
+            return summaryText;
         } catch (error) {
-            throw new Error(`Realtime 요약 생성 실패: ${error.message}`);
+            throw new Error(`Chat API 요약 생성 실패: ${error.message}`);
         }
     }
 
     async generateSessionReport(llmService, sessionId, options = {}) {
         const { theme = "light", format = "image" } = options; // format: "image" | "html" | "both"
 
-        const summaryText = await this._getStructuredSummaryFromRealtime(
+        const summaryText = await this._getStructuredSummaryFromChat(
             llmService,
             sessionId
         );

--- a/service/summaryService.js
+++ b/service/summaryService.js
@@ -33,7 +33,7 @@ class SummaryService {
         }
     }
 
-    // Realtime API에서 직접 구조화된 요약 요청 (효율적)
+    // Realtime API에서 직접 구조화된 요약 요청 (silent 모드 사용)
     async _getStructuredSummaryFromRealtime(llmService, sessionId) {
         try {
             const summaryPrompt = `지금까지의 고객 상담 내용을 담당자 인수인계용으로 정확하고 자세하게 구조화해서 요약해주세요.
@@ -68,7 +68,8 @@ class SummaryService {
 
             const response = await llmService.sendTextMessageWithResponse(
                 sessionId,
-                summaryPrompt
+                summaryPrompt,
+                { silent: true }
             );
             return response.text;
         } catch (error) {

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -343,10 +343,17 @@ class Socket {
         });
 
         fwd("text_done", () => {
+            return {
+                type: "response.text.done",
+                output_index: this._getTurnCount(sessionId),
+            };
+        });
+
+        fwd("response_done", () => {
             this._generateSuggestionsAfterResponse(ws, sessionId);
 
             return {
-                type: "response.text.done",
+                type: "response.done",
                 output_index: this._getTurnCount(sessionId),
             };
         });


### PR DESCRIPTION
## 연관된 이슈
#34 
## 작업 내용
-  `llmService` 에서 silent 모드 확인 후에 서버 소켓으로 데이터 전송
- `summarySerivce` 에서 silent 모드 설정 후에 요약 요청
- 배포환경 브라우저를 위한 `Dockerfile` 수정
- style 수정
## 스크린 샷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 오디오 응답 지원(텍스트와 병행)
  - 세션별 대화 기록 유지로 맥락 있는 응답
  - 대화 기반 요약 생성 기능 추가

- Refactor
  - 요약 생성을 Chat API 기반으로 전환
  - 스트리밍 텍스트 누적·기록 반영 로직 개선
  - 소켓 이벤트 명명 일관성 개선

- Chores
  - Docker 이미지에 Chromium을 포함해 Puppeteer 실행 환경 내장(추가 다운로드 방지)

- Style
  - RAG 검색 관련 코드 포매팅 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->