### PR TITLE
음성 output index가 -1이 되던 문제 해결

### DIFF
--- a/service/llmService.js
+++ b/service/llmService.js
@@ -381,15 +381,13 @@ class LLMService extends EventEmitter {
       audio: base64Pcm16Chunk,
     });
   }
-  commitAudioAndCreateResponse(
-    sessionId,
-    { modalities = ["text", "audio"] } = {}
-  ) {
+  commitAudio(sessionId) {
     const ws = this._needWs(sessionId);
+    console.log(0);
     this._send(ws, { type: "input_audio_buffer.commit" });
-    this._send(ws, { type: "response.create", response: { modalities } });
   }
   clearAudioBuffer(sessionId) {
+    console.log(9);
     const ws = this._needWs(sessionId);
     this._send(ws, { type: "input_audio_buffer.clear" });
   }
@@ -432,6 +430,11 @@ class LLMService extends EventEmitter {
             sessionId,
             itemId: data.item_id,
             // output_index: data.output_index,
+          });
+          console.log(1);
+          this._send(ws, {
+            type: "response.create",
+            response: { modalities: ["text", "audio"] },
           });
           break;
 

--- a/service/llmService.js
+++ b/service/llmService.js
@@ -383,11 +383,9 @@ class LLMService extends EventEmitter {
   }
   commitAudio(sessionId) {
     const ws = this._needWs(sessionId);
-    console.log(0);
     this._send(ws, { type: "input_audio_buffer.commit" });
   }
   clearAudioBuffer(sessionId) {
-    console.log(9);
     const ws = this._needWs(sessionId);
     this._send(ws, { type: "input_audio_buffer.clear" });
   }
@@ -431,7 +429,6 @@ class LLMService extends EventEmitter {
             itemId: data.item_id,
             // output_index: data.output_index,
           });
-          console.log(1);
           this._send(ws, {
             type: "response.create",
             response: { modalities: ["text", "audio"] },

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -172,7 +172,6 @@ class Socket {
     const { type } = msg;
 
     if (type === "input_audio_buffer.commit") {
-      console.log(10);
       try {
         llmService.clearAudioBuffer(sessionId);
       } catch {}

--- a/socket/socket.js
+++ b/socket/socket.js
@@ -172,6 +172,7 @@ class Socket {
     const { type } = msg;
 
     if (type === "input_audio_buffer.commit") {
+      console.log(10);
       try {
         llmService.clearAudioBuffer(sessionId);
       } catch {}
@@ -189,9 +190,7 @@ class Socket {
 
     if (type === "input_audio_buffer.end") {
       try {
-        llmService.commitAudioAndCreateResponse(sessionId, {
-          modalities: ["text", "audio"],
-        });
+        llmService.commitAudio(sessionId);
       } catch (e) {
         return this._sendError(ws, 500, `Commit failed: ${e.message}`);
       }


### PR DESCRIPTION
## 연관된 이슈
#52 
## 작업 내용
- Commited 이벤트 받은 후 response.create 하도록 수정
## 스크린 샷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 오디오 커밋 절차가 단일 단계로 간소화되어 처리 흐름이 명확해졌습니다.
  - 오디오 커밋 직후 즉시 응답을 생성하지 않고, 커밋 완료 이벤트 확인 후 텍스트·오디오 응답을 생성하도록 시점을 조정했습니다. 이로 인해 응답 도착 타이밍이 소폭 달라질 수 있습니다.
- Chores
  - 실행 흐름 추적을 위한 진단 로그가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->